### PR TITLE
Allow client to specify tab bar height

### DIFF
--- a/Pod/Classes/SideMenuNavigationController.swift
+++ b/Pod/Classes/SideMenuNavigationController.swift
@@ -93,6 +93,7 @@ public struct SideMenuSettings: Model, InitializableStruct {
         let minimumSize = min(appScreenRect.width, appScreenRect.height)
         return min(round(minimumSize * 0.75), 240)
     }()
+    public var tabBarHeight: CGFloat = 0
     public var presentingViewControllerUserInteractionEnabled: Bool = false
     public var presentingViewControllerUseSnapshot: Bool = false
     public var presentDuration: Double = 0.35
@@ -423,6 +424,11 @@ extension SideMenuNavigationController: Model {
         set { settings.menuWidth = newValue }
     }
 
+    @IBInspectable open var tabBarHeight: CGFloat {
+        get { return settings.tabBarHeight }
+        set { settings.tabBarHeight = newValue }
+    }
+    
     @IBInspectable open var presentingViewControllerUserInteractionEnabled: Bool {
         get { return settings.presentingViewControllerUserInteractionEnabled }
         set { settings.presentingViewControllerUserInteractionEnabled = newValue }

--- a/Pod/Classes/SideMenuPresentationController.swift
+++ b/Pod/Classes/SideMenuPresentationController.swift
@@ -18,6 +18,8 @@ internal protocol PresentationModel {
     var presentationStyle: SideMenuPresentationStyle { get }
     /// Width of the menu when presented on screen, showing the existing view controller in the remaining space. Default is zero.
     var menuWidth: CGFloat { get }
+    /// Height of tab bar if visible. The height of the menu will be adjusted to not cover the tab bar. Default is zero.
+    var tabBarHeight: CGFloat { get }
 }
 
 internal protocol SideMenuPresentationControllerDelegate: class {
@@ -222,16 +224,9 @@ private extension SideMenuPresentationController {
     var frameOfPresentedViewInContainerView: CGRect {
         guard let containerView = containerView else { return .zero }
         var rect = containerView.bounds
-        let window = UIApplication.shared.windows.filter(\.isKeyWindow).first
-        let tabBarHeight: CGFloat = 49.0
-        var tabBarVisible: Bool = true
 
-        if let tabBarController = presentingViewController as? UITabBarController, tabBarController.tabBar.isHidden {
-            tabBarVisible = false
-        }
-
-        if tabBarVisible {
-            rect.size.height -= (tabBarHeight + (window?.safeAreaInsets.bottom ?? 0))
+        if config.tabBarHeight != 0 {
+            rect.size.height -= (config.tabBarHeight + (containerView.window?.safeAreaInsets.bottom ?? 0))
         }
 
         rect.origin.x = leftSide ? 0 : rect.width - config.menuWidth


### PR DESCRIPTION
I added support to specify the tab bar height as a setting instead of trying to check for a `UITabBarController` during presentation.

This is needed to be able to account for having a tab bar, but not using a `UITabBarController`.